### PR TITLE
made signatureStampPosition nullable

### DIFF
--- a/src/main/kotlin/com/broeskamp/postident/dto/request/Document.kt
+++ b/src/main/kotlin/com/broeskamp/postident/dto/request/Document.kt
@@ -69,5 +69,5 @@ data class Document(
     /**
      * Position of the signature stamp. This Field could be overwritten by the signatureStamp Position in SignerDocumentInfo.
      */
-    val signatureStampPosition: SignatureStampPosition
+    val signatureStampPosition: SignatureStampPosition?
 )


### PR DESCRIPTION
As stated in the documentation: 

> Position of the signature stamp. This Field could be overwritten by the signatureStamp Position in SignerDocumentInfo.

the signatureStampPosition can be overwirtten by `signatureStamp` in `SignerDocumentInfo`. Therefore it should be nullable. 